### PR TITLE
change: 使用 require 确保插件加载再 import

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,13 @@ _✨ NoneBot 数据存储插件 ✨_
 
 ## 使用方式
 
-加载插件后直接导出方法
+加载插件后直接导入
 
 ```python
+# 先声明依赖
+from nonebot import require
+require("nonebot_plugin_datastore")
+# 接着直接导入
 from nonebot.params import Depends
 from nonebot_plugin_datastore import PluginData, get_session
 from sqlmodel.ext.asyncio.session import AsyncSession

--- a/nonebot_plugin_datastore/config.py
+++ b/nonebot_plugin_datastore/config.py
@@ -5,12 +5,13 @@ from typing import Dict
 from nonebot import get_driver, require
 from pydantic import BaseModel, Extra, root_validator
 
-store = require("nonebot_plugin_localstore")
+require("nonebot_plugin_localstore")
+from nonebot_plugin_localstore import get_cache_dir, get_config_dir, get_data_dir
 
 # 默认目录
-BASE_CACHE_DIR: Path = Path(store.get_cache_dir(""))
-BASE_CONFIG_DIR: Path = Path(store.get_config_dir(""))
-BASE_DATA_DIR: Path = Path(store.get_data_dir(""))
+BASE_CACHE_DIR: Path = Path(get_cache_dir(""))
+BASE_CONFIG_DIR: Path = Path(get_config_dir(""))
+BASE_DATA_DIR: Path = Path(get_data_dir(""))
 
 
 class Config(BaseModel, extra=Extra.ignore):


### PR DESCRIPTION
当前的推荐写法，可以获得类型信息且能确保插件加载

>确保插件加载和跨插件访问
倘若 plugin_a, plugin_b 均需被加载, 且 plugin_b 插件需要导入 plugin_a 才可运行, 可以在 plugin-b 利用 require 方法来确保插件加载, 同时可以直接 import 导入 plugin-a ,进行跨插件访问。