### PR TITLE
feat: 添加 pre_db_init 钩子

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 
 ## [Unreleased]
 
+### Added
+
+- 添加 pre_db_init 钩子
+
 ## [0.5.1] - 2023-01-15
 
 ### Fixed

--- a/tests/example/__init__.py
+++ b/tests/example/__init__.py
@@ -10,7 +10,7 @@ from .models import Example
 @post_db_init
 async def _():
     async with create_session() as session:
-        example = Example(message="init")
+        example = Example(message="post")
         session.add(example)
         await session.commit()
 

--- a/tests/example2/__init__.py
+++ b/tests/example2/__init__.py
@@ -2,9 +2,18 @@ from nonebot import on_command
 from nonebot.params import Depends
 
 from nonebot_plugin_datastore import get_session
-from nonebot_plugin_datastore.db import AsyncSession
+from nonebot_plugin_datastore.db import AsyncSession, create_session, pre_db_init
 
 from .models import Example2
+
+
+@pre_db_init
+async def _():
+    async with create_session() as session:
+        example = Example2(message2="pre")
+        session.add(example)
+        await session.commit()
+
 
 test2 = on_command("test2")
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -23,7 +23,7 @@ async def test_db(app: App):
         statement = select(Example)
         result = await session.exec(statement)  # type: ignore
         example = cast(Example, result.first())
-        assert example.message == "init"
+        assert example.message == "post"
 
     async with create_session() as session:
         session.add(Example(message="test"))
@@ -102,5 +102,16 @@ async def test_post_db_init_error(nonebug_init: None):
     @post_db_init
     async def _():
         raise Exception("test")
+
+    await init_db()
+
+
+async def test_pre_db_init_error(nonebug_init: None):
+    """数据库初始化前执行函数错误"""
+    from nonebot import require
+
+    from nonebot_plugin_datastore.db import init_db
+
+    require("tests.example2")
 
     await init_db()


### PR DESCRIPTION
nonebot-bison 需要在数据库初始化前将 version_table 重命名，才能继续进行迁移操作。