### PR TITLE
refactor: 简化 env.py

### DIFF
--- a/nonebot_plugin_datastore/script/migration/env.py
+++ b/nonebot_plugin_datastore/script/migration/env.py
@@ -1,22 +1,5 @@
 import asyncio
 
-from alembic import context
-
 from nonebot_plugin_datastore.script.utils import run_migration
 
-# this is the Alembic Config object, which provides
-# access to the values within the .ini file in use.
-config = context.config
-
-plugin_name = config.get_main_option("plugin_name")
-
-if not plugin_name:
-    raise RuntimeError("未指定插件名称")  # pragma: no cover
-
-if config.cmd_opts and config.cmd_opts.autogenerate:
-    autogenerate = True
-else:
-    autogenerate = False
-
-if not context.is_offline_mode():
-    asyncio.run(run_migration(plugin_name, autogenerate))
+asyncio.run(run_migration())


### PR DESCRIPTION
完全可以把获取插件名放到 do_run_migrations 中。