### PR TITLE
change: 默认开启 render_as_batch 以支持 SQLite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 
 ## [Unreleased]
 
+### Changed
+
+- 默认开启 render_as_batch
+
 ## [0.5.2] - 2023-01-15
 
 ### Added

--- a/nonebot_plugin_datastore/script/utils.py
+++ b/nonebot_plugin_datastore/script/utils.py
@@ -96,6 +96,7 @@ def do_run_migrations(connection, plugin_name: Optional[str] = None):
         version_table=f"{plugin_name}_alembic_version",
         include_object=include_object,
         process_revision_directives=process_revision_directives,
+        render_as_batch=True,
     )
 
     with context.begin_transaction():


### PR DESCRIPTION
参考资料：<https://alembic.sqlalchemy.org/en/latest/batch.html>

>The SQLite database presents a challenge to migration tools in that it has almost no support for the ALTER statement which relational schema migrations rely upon. The rationale for this stems from philosophical and architectural concerns within SQLite, and they are unlikely to be changed.
>
>Migration tools are instead expected to produce copies of SQLite tables that correspond to the new structure, transfer the data from the existing table to the new one, then drop the old table. For our purposes here we’ll call this “move and copy” workflow, and in order to accommodate it in a way that is reasonably predictable, while also remaining compatible with other databases, Alembic provides the batch operations context.
>
>Within this context, a relational table is named, and then a series of mutation operations to that table alone are specified within the block. When the context is complete, a process begins whereby the “move and copy” procedure begins; the existing table structure is reflected from the database, a new version of this table is created with the given changes, data is copied from the old table to the new table using “INSERT from SELECT”, and finally the old table is dropped and the new one renamed to the original name.