### PR TITLE
change: 默认开启 compare_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 
 ## [Unreleased]
 
+### Changed
+
+- 默认开启 compare_type
+
 ## [0.5.3] - 2023-01-16
 
 ### Changed

--- a/nonebot_plugin_datastore/script/utils.py
+++ b/nonebot_plugin_datastore/script/utils.py
@@ -97,6 +97,7 @@ def do_run_migrations(connection, plugin_name: Optional[str] = None):
         include_object=include_object,
         process_revision_directives=process_revision_directives,
         render_as_batch=True,
+        compare_type=True,
     )
 
     with context.begin_transaction():

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -65,13 +65,18 @@ async def test_disable_db(app: App):
     assert str(e.value) == "数据库未启用"
 
 
-async def test_default_db_url(app: None):
+async def test_default_db_url(nonebug_init: None):
     """测试默认数据库地址"""
-    from nonebot_plugin_datastore.config import plugin_config
+    import nonebot
+
+    # 加载插件
+    nonebot.load_plugin("nonebot_plugin_datastore")
+
+    from nonebot_plugin_datastore.config import BASE_DATA_DIR, plugin_config
 
     assert (
         plugin_config.datastore_database_url
-        == f"sqlite+aiosqlite:///{plugin_config.datastore_data_dir / 'data.db'}"
+        == f"sqlite+aiosqlite:///{BASE_DATA_DIR / 'data.db'}"
     )
 
 


### PR DESCRIPTION
只有开启这个选项才能识别出字段长度变化。

参考资料：<https://alembic.sqlalchemy.org/en/latest/autogenerate.html#what-does-autogenerate-detect-and-what-does-it-not-detect>

>Change of column type. This will occur if you set the [EnvironmentContext.configure.compare_type](https://alembic.sqlalchemy.org/en/latest/api/runtime.html#alembic.runtime.environment.EnvironmentContext.configure.params.compare_type) parameter to True. The default implementation will reliably detect major changes, such as between Numeric and String, as well as accommodate for the types generated by SQLAlchemy’s “generic” types such as Boolean. Arguments that are shared between both types, such as length and precision values, will also be compared. If either the metadata type or database type has additional arguments beyond that of the other type, these are not compared, such as if one numeric type featured a “scale” and other type did not, this would be seen as the backing database not supporting the value, or reporting on a default that the metadata did not specify.