### PR TITLE
feat: 添加 migrate 命令

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 ### Added
 
 - 添加 history, current, heads, check 命令
+- 添加 migrate 命令
 
 ## [0.5.4] - 2023-01-16
 

--- a/nonebot_plugin_datastore/script/cli.py
+++ b/nonebot_plugin_datastore/script/cli.py
@@ -23,15 +23,23 @@ def cli():
     ),
 )
 def revision(name: Optional[str], message: Optional[str], autogenerate: bool):
-    """revision"""
+    """创建迁移文件"""
     command.revision(name=name, message=message, autogenerate=autogenerate)
+
+
+@cli.command()
+@click.option("--name", "-n", default=None, help="插件名")
+@click.option("-m", "--message", default=None, help="Revision message")
+def migrate(name: Optional[str], message: Optional[str]):
+    """自动根据模型更改创建迁移文件"""
+    command.revision(name=name, message=message, autogenerate=True)
 
 
 @cli.command()
 @click.option("--name", "-n", default=None, help="插件名")
 @click.argument("revision", default="head")
 def upgrade(name: Optional[str], revision: str):
-    """upgrade"""
+    """升级数据库版本"""
     command.upgrade(name=name, revision=revision)
 
 
@@ -39,7 +47,7 @@ def upgrade(name: Optional[str], revision: str):
 @click.option("--name", "-n", default=None, help="插件名")
 @click.argument("revision", default="-1")
 def downgrade(name: Optional[str], revision: str):
-    """downgrade"""
+    """降级数据库版本"""
     command.downgrade(name=name, revision=revision)
 
 
@@ -49,6 +57,7 @@ def downgrade(name: Optional[str], revision: str):
 @click.option("--verbose", "-v", is_flag=True, help="显示详细信息")
 @click.option(
     "--indicate-current",
+    "-i",
     is_flag=True,
     help="Indicate current revisions with (head) and (current)",
 )
@@ -58,7 +67,7 @@ def history(
     verbose: bool,
     indicate_current: bool,
 ):
-    """history"""
+    """数据库版本历史"""
     command.history(
         name=name,
         rev_range=rev_range,
@@ -71,7 +80,7 @@ def history(
 @click.option("--name", "-n", default=None, help="插件名")
 @click.option("--verbose", "-v", is_flag=True, help="显示详细信息")
 def current(name: Optional[str], verbose: bool):
-    """current"""
+    """数据库当前版本"""
     command.current(name=name, verbose=verbose)
 
 
@@ -79,14 +88,14 @@ def current(name: Optional[str], verbose: bool):
 @click.option("--name", "-n", default=None, help="插件名")
 @click.option("--verbose", "-v", is_flag=True, help="显示详细信息")
 def heads(name: Optional[str], verbose: bool):
-    """heads"""
+    """数据库最新版本"""
     command.heads(name=name, verbose=verbose)
 
 
 @cli.command()
 @click.option("--name", "-n", default=None, help="插件名")
 def check(name: Optional[str]):
-    """check"""
+    """数据库是否需要升级"""
     command.check(name=name)
 
 


### PR DESCRIPTION
因为 autogenerate 特别常用，所以参考 Flask-Migrate 增加一个 migrate 命令（默认启用 autogenerate 的 revision 命令）。 