### PR TITLE
fix: 数据库初始化前执行的函数运行出错，则不继续执行后续初始化

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 ### Fixed
 
 - 修复缺少 nb_cli 模块的问题
+- 数据库初始化前执行的函数运行出错，则不继续执行后续初始化
 
 ## [0.5.6] - 2023-01-26
 

--- a/nonebot_plugin_datastore/db.py
+++ b/nonebot_plugin_datastore/db.py
@@ -53,7 +53,8 @@ async def init_db():
         try:
             await asyncio.gather(*cors)
         except Exception as e:
-            logger.error(f"数据库初始化前执行的函数出错: {e}")
+            logger.error("数据库初始化前执行的函数出错")
+            raise
 
     # 兼容以前不支持迁移的版本
     async with get_engine().begin() as conn:

--- a/nonebot_plugin_datastore/script/cli.py
+++ b/nonebot_plugin_datastore/script/cli.py
@@ -91,7 +91,7 @@ async def upgrade(name: Optional[str], revision: str):
         try:
             await asyncio.gather(*cors)
         except Exception as e:
-            logger.error("数据库初始化前执行的函数出错")
+            click.echo("数据库初始化前执行的函数出错")
             raise
     plugins = get_plugins(name)
     for plugin in plugins:

--- a/nonebot_plugin_datastore/script/cli.py
+++ b/nonebot_plugin_datastore/script/cli.py
@@ -1,3 +1,4 @@
+import asyncio
 from argparse import Namespace
 from functools import partial, wraps
 from typing import Any, Callable, Coroutine, Optional, TypeVar
@@ -5,9 +6,11 @@ from typing import Any, Callable, Coroutine, Optional, TypeVar
 import anyio
 import click
 from nonebot.log import logger
+from nonebot.utils import is_coroutine_callable
 from typing_extensions import ParamSpec
 
 from ..config import plugin_config
+from ..db import _pre_db_init_funcs
 from ..plugin import PluginData
 from . import command
 from .utils import Config, get_plugins
@@ -78,6 +81,18 @@ async def migrate(name: Optional[str], message: Optional[str]):
 @run_async
 async def upgrade(name: Optional[str], revision: str):
     """升级数据库版本"""
+    # 执行数据库初始化前执行的函数
+    # 比如 bison 需要在迁移之前把 alembic_version 表重命名
+    cors = [
+        func() if is_coroutine_callable(func) else run_sync(func)()
+        for func in _pre_db_init_funcs
+    ]
+    if cors:
+        try:
+            await asyncio.gather(*cors)
+        except Exception as e:
+            logger.error("数据库初始化前执行的函数出错")
+            raise
     plugins = get_plugins(name)
     for plugin in plugins:
         logger.info(f"升级插件 {plugin} 的数据库")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -128,6 +128,11 @@ async def test_upgrade(app: App):
     assert result.exit_code == 0
     assert result.output == ""
 
+    require("tests.example2")
+    result = await run_sync(runner.invoke)(cli, ["upgrade"])
+    assert result.exit_code == 1
+    assert result.output == "数据库初始化前执行的函数出错\n"
+
 
 @pytest.mark.anyio
 async def test_downgrade(app: App):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -38,12 +38,12 @@ async def test_revision(app: App, tmp_path: Path):
     from nonebot import require
 
     from nonebot_plugin_datastore import PluginData
-    from nonebot_plugin_datastore.db import init_db
     from nonebot_plugin_datastore.script.cli import cli, run_sync
+    from nonebot_plugin_datastore.script.utils import run_upgrade
 
     require("tests.example")
     require("tests.example2")
-    await init_db()
+    await run_upgrade()
 
     runner = CliRunner()
 
@@ -83,12 +83,12 @@ async def test_migrate(app: App, tmp_path: Path):
     from nonebot import require
 
     from nonebot_plugin_datastore import PluginData
-    from nonebot_plugin_datastore.db import init_db
     from nonebot_plugin_datastore.script.cli import cli, run_sync
+    from nonebot_plugin_datastore.script.utils import run_upgrade
 
     require("tests.example")
     require("tests.example2")
-    await init_db()
+    await run_upgrade()
 
     runner = CliRunner()
 
@@ -149,8 +149,8 @@ async def test_downgrade(app: App):
 async def test_other_commands(app: App):
     from nonebot import require
 
-    from nonebot_plugin_datastore.db import init_db
     from nonebot_plugin_datastore.script.cli import cli, run_sync
+    from nonebot_plugin_datastore.script.utils import run_upgrade
 
     require("tests.example")
     require("tests.example2")
@@ -172,7 +172,7 @@ async def test_other_commands(app: App):
     assert result.exit_code == 1
     assert result.output == ""
 
-    await init_db()
+    await run_upgrade()
 
     result = await run_sync(runner.invoke)(cli, ["check", "--name", "example"])
     assert result.exit_code == 0

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -99,7 +99,8 @@ async def test_pre_db_init_error(app: None):
 
     require("tests.example2")
 
-    await init_db()
+    with pytest.raises(Exception):
+        await init_db()
 
 
 async def test_compatibility(app: None):


### PR DESCRIPTION
pre_db_init 的操作，对于正常迁移，一般来说很重要，所以一旦这个出错，应该直接退出迁移步骤，防止出现难以修复的问题。