### PR TITLE
fix: 修复运行中删除目录导致报错的问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 
 ## [Unreleased]
 
+### Fixed
+
+- 修复运行中删除目录导致报错的问题
+
 ## [0.5.8] - 2023-02-10
 
 ### Added

--- a/nonebot_plugin_datastore/config.py
+++ b/nonebot_plugin_datastore/config.py
@@ -8,36 +8,45 @@ from pydantic import BaseModel, Extra, root_validator
 require("nonebot_plugin_localstore")
 from nonebot_plugin_localstore import get_cache_dir, get_config_dir, get_data_dir
 
-# 默认目录
-BASE_CACHE_DIR: Path = Path(get_cache_dir(""))
-BASE_CONFIG_DIR: Path = Path(get_config_dir(""))
-BASE_DATA_DIR: Path = Path(get_data_dir(""))
-
 
 class Config(BaseModel, extra=Extra.ignore):
-    datastore_cache_dir: Path = BASE_CACHE_DIR
-    datastore_config_dir: Path = BASE_CONFIG_DIR
-    datastore_data_dir: Path = BASE_DATA_DIR
-    datastore_enable_database: bool = True
+    datastore_cache_dir: Path
+    datastore_config_dir: Path
+    datastore_data_dir: Path
     datastore_database_url: str
     """数据库连接字符串
 
     默认使用 SQLite
     """
+    datastore_enable_database: bool = True
     datastore_database_echo: bool = False
 
     @root_validator(pre=True, allow_reuse=True)
-    def set_database_url(cls, values: Dict):
-        database_url = values.get("datastore_database_url")
-        data_dir = values.get("datastore_data_dir")
-        if database_url is None:
-            if data_dir is None:
-                data_dir = BASE_DATA_DIR
-            else:
-                data_dir = Path(data_dir)
+    def set_defaults(cls, values: Dict):
+        """设置默认值"""
+        # 设置默认目录
+        # 仅在未设置时调用 get_*_dir 函数，因为这些函数会自动创建目录
+        values["datastore_cache_dir"] = (
+            Path(cache_dir)
+            if (cache_dir := values.get("datastore_cache_dir"))
+            else Path(get_cache_dir(""))
+        )
+        values["datastore_config_dir"] = (
+            Path(config_dir)
+            if (config_dir := values.get("datastore_config_dir"))
+            else Path(get_config_dir(""))
+        )
+        values["datastore_data_dir"] = (
+            Path(data_dir)
+            if (data_dir := values.get("datastore_data_dir"))
+            else Path(get_data_dir(""))
+        )
+
+        # 设置默认数据库连接字符串
+        if not values.get("datastore_database_url"):
             values[
                 "datastore_database_url"
-            ] = f"sqlite+aiosqlite:///{data_dir / 'data.db'}"
+            ] = f"sqlite+aiosqlite:///{values['datastore_data_dir'] / 'data.db'}"
         return values
 
 

--- a/nonebot_plugin_datastore/plugin.py
+++ b/nonebot_plugin_datastore/plugin.py
@@ -1,7 +1,6 @@
 """ 插件数据 """
 import inspect
 import json
-import os
 import pickle
 from functools import lru_cache
 from pathlib import Path
@@ -183,18 +182,22 @@ class PluginData(metaclass=Singleton):
         self._model = None
         self._migration_path = None
 
-        # 插件目录
-        self._cache_dir = None
-        self._config_dir = None
-        self._data_dir = None
+    @staticmethod
+    def _ensure_dir(path: Path):
+        """确保目录存在"""
+        if not path.exists():
+            path.mkdir(parents=True, exist_ok=True)
+        elif not path.is_dir():
+            raise RuntimeError(f"{path} 不是目录")
 
     @property
     def cache_dir(self) -> Path:
         """缓存目录"""
-        if self._cache_dir is None:
-            self._cache_dir = plugin_config.datastore_cache_dir / self._name
-            os.makedirs(self.cache_dir, exist_ok=True)
-        return self._cache_dir
+        directory = plugin_config.datastore_cache_dir / self._name
+        # 每次调用都检查一下目录是否存在
+        # 防止运行时有人删除目录
+        self._ensure_dir(directory)
+        return directory
 
     @property
     def config_dir(self) -> Path:
@@ -202,18 +205,16 @@ class PluginData(metaclass=Singleton):
 
         配置都放置在统一的目录下
         """
-        if self._config_dir is None:
-            self._config_dir = plugin_config.datastore_config_dir
-            os.makedirs(self._config_dir, exist_ok=True)
-        return self._config_dir
+        directory = plugin_config.datastore_config_dir
+        self._ensure_dir(directory)
+        return directory
 
     @property
     def data_dir(self) -> Path:
         """数据目录"""
-        if self._data_dir is None:
-            self._data_dir = plugin_config.datastore_data_dir / self._name
-            os.makedirs(self._data_dir, exist_ok=True)
-        return self._data_dir
+        directory = plugin_config.datastore_data_dir / self._name
+        self._ensure_dir(directory)
+        return directory
 
     @property
     def config(self) -> Config:

--- a/poetry.lock
+++ b/poetry.lock
@@ -495,19 +495,19 @@ testing = ["pre-commit"]
 
 [[package]]
 name = "fastapi"
-version = "0.90.1"
+version = "0.91.0"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "fastapi-0.90.1-py3-none-any.whl", hash = "sha256:d4e4bd820204eeaa19879bf129bbce73db09bdc209d5d83a064b40b2b00557b0"},
-    {file = "fastapi-0.90.1.tar.gz", hash = "sha256:d17e85deb3a350b731467e7bf035e158faffa381310a1b7356421e916fcc64f2"},
+    {file = "fastapi-0.91.0-py3-none-any.whl", hash = "sha256:8dc18f860755159b3c4b30577c61c821b98f382acfeb6d5a849f9fa6a5369789"},
+    {file = "fastapi-0.91.0.tar.gz", hash = "sha256:ff2fa93af3f2f982b07b5f96e8512565b3ef0e5f8f02469dbfd6bc27f6fd9a9e"},
 ]
 
 [package.dependencies]
 pydantic = ">=1.6.2,<1.7 || >1.7,<1.7.1 || >1.7.1,<1.7.2 || >1.7.2,<1.7.3 || >1.7.3,<1.8 || >1.8,<1.8.1 || >1.8.1,<2.0.0"
-starlette = ">=0.22.0,<0.24.0"
+starlette = ">=0.24.0,<0.25.0"
 
 [package.extras]
 all = ["email-validator (>=1.1.1)", "httpx (>=0.23.0)", "itsdangerous (>=1.1.0)", "jinja2 (>=2.11.2)", "orjson (>=3.2.1)", "python-multipart (>=0.0.5)", "pyyaml (>=5.3.1)", "ujson (>=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0)", "uvicorn[standard] (>=0.12.0)"]
@@ -760,14 +760,14 @@ files = [
 
 [[package]]
 name = "identify"
-version = "2.5.17"
+version = "2.5.18"
 description = "File identification library for Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "identify-2.5.17-py2.py3-none-any.whl", hash = "sha256:7d526dd1283555aafcc91539acc061d8f6f59adb0a7bba462735b0a318bff7ed"},
-    {file = "identify-2.5.17.tar.gz", hash = "sha256:93cc61a861052de9d4c541a7acb7e3dcc9c11b398a2144f6e52ae5285f5f4f06"},
+    {file = "identify-2.5.18-py2.py3-none-any.whl", hash = "sha256:93aac7ecf2f6abf879b8f29a8002d3c6de7086b8c28d88e1ad15045a15ab63f9"},
+    {file = "identify-2.5.18.tar.gz", hash = "sha256:89e144fa560cc4cffb6ef2ab5e9fb18ed9f9b3cb054384bab4b95c12f6c309fe"},
 ]
 
 [package.extras]
@@ -1129,18 +1129,19 @@ setuptools = "*"
 
 [[package]]
 name = "nonebot-plugin-localstore"
-version = "0.3.1"
+version = "0.4.1"
 description = "Local Storage Support for NoneBot2"
 category = "main"
 optional = false
 python-versions = ">=3.8,<4.0"
 files = [
-    {file = "nonebot_plugin_localstore-0.3.1-py3-none-any.whl", hash = "sha256:5a03e731a354105741852121fa6fa30508ad9c1b93eb9f42f8ba02924128a985"},
-    {file = "nonebot_plugin_localstore-0.3.1.tar.gz", hash = "sha256:fa332f5b887d8a77aaffc48a30e8f57a8c668bb761b678822f64075eec3dfa4e"},
+    {file = "nonebot_plugin_localstore-0.4.1-py3-none-any.whl", hash = "sha256:dea442fcf8baa5898c15ccea761703cdde46e6fc6bb1c886261b0ab793db8193"},
+    {file = "nonebot_plugin_localstore-0.4.1.tar.gz", hash = "sha256:9b6dcb98f6a4e48c5c80b2319acc2e1c424462261a210491d437f5b96abb5d67"},
 ]
 
 [package.dependencies]
 nonebot2 = ">=2.0.0-rc.1,<3.0.0"
+typing-extensions = ">=4.0.0"
 
 [[package]]
 name = "nonebot2"
@@ -1764,14 +1765,14 @@ sqlalchemy2-stubs = "*"
 
 [[package]]
 name = "starlette"
-version = "0.23.1"
+version = "0.24.0"
 description = "The little ASGI library that shines."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "starlette-0.23.1-py3-none-any.whl", hash = "sha256:ec69736c90be8dbfc6ec6800ba6feb79c8c44f9b1706c0b2bb27f936bcf362cc"},
-    {file = "starlette-0.23.1.tar.gz", hash = "sha256:8510e5b3d670326326c5c1d4cb657cc66832193fe5d5b7015a51c7b1e1b1bf42"},
+    {file = "starlette-0.24.0-py3-none-any.whl", hash = "sha256:75e2b24d71ff4f7cb9a3338f83d234c2d4135bf80f52aeb105c02a01d72a5df1"},
+    {file = "starlette-0.24.0.tar.gz", hash = "sha256:7925947f177a19e906c6ace10f07c64c4f9fdf7d509caaac6589f7cc0cfd95f3"},
 ]
 
 [package.dependencies]
@@ -2184,4 +2185,4 @@ cli = ["anyio", "click", "typing-extensions"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "9938f628e7f1b9d496c42fdab223e2f36b40d4cea46676d88c982f2ef21601ec"
+content-hash = "70d33ec780b326624a4b07df06c3355d51bc155fa6156db41210d90bddebf39d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ documentation = "https://github.com/he0119/nonebot-plugin-datastore#readme"
 [tool.poetry.dependencies]
 python = "^3.8"
 nonebot2 = { extras = ["httpx"], version = "^2.0.0-rc.1" }
-nonebot-plugin-localstore = ">=0.2.0,!=0.3.0,<0.4.0"
+nonebot-plugin-localstore = ">=0.2.0,!=0.3.0,!=0.4.0,<0.5.0"
 sqlmodel = ">=0.0.8,<0.1.0"
 aiosqlite = ">=0.17,<0.19"
 alembic = "^1.9.1"

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -72,11 +72,11 @@ async def test_default_db_url(nonebug_init: None):
     # 加载插件
     nonebot.load_plugin("nonebot_plugin_datastore")
 
-    from nonebot_plugin_datastore.config import BASE_DATA_DIR, plugin_config
+    from nonebot_plugin_datastore.config import plugin_config
 
     assert (
         plugin_config.datastore_database_url
-        == f"sqlite+aiosqlite:///{BASE_DATA_DIR / 'data.db'}"
+        == f"sqlite+aiosqlite:///{plugin_config.datastore_data_dir / 'data.db'}"
     )
 
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -15,3 +15,17 @@ async def test_get_plugin_data_failed(app: App):
         import tests.example
 
     assert e.value.args[0] == "插件名称为空，且自动获取失败"
+
+
+async def test_plugin_dir_is_file(app: App):
+    """插件数据文件夹已经存在且为文件"""
+    from nonebot_plugin_datastore import PluginData
+    from nonebot_plugin_datastore.config import plugin_config
+
+    plugin_dir = plugin_config.datastore_data_dir / "test"
+    plugin_dir.touch()
+    assert plugin_dir.is_file()
+
+    data = PluginData("test")
+    with pytest.raises(RuntimeError):
+        data.data_dir


### PR DESCRIPTION
机器人启动后，如果删除相应的目录，会报错。所以每次调用目录地址都确认一下目录存在，防止这种情况发生。

同时支持最新的 localstore。