### PR TITLE
fix: 调整 ConfigProvider 导入时机，防止数据库没有正常初始化

### DIFF
--- a/nonebot_plugin_datastore/plugin.py
+++ b/nonebot_plugin_datastore/plugin.py
@@ -2,7 +2,7 @@
 import json
 import pickle
 from pathlib import Path
-from typing import IO, Any, Callable, Generic, Optional, Type, TypeVar
+from typing import Any, Callable, Generic, Optional, Type, TypeVar
 
 import httpx
 from nonebot import _resolve_dot_notation, get_plugin
@@ -151,12 +151,7 @@ class PluginData(metaclass=Singleton):
     def config(self) -> ConfigProvider:
         """获取配置管理"""
         if not self._config:
-            ProviderClass = _resolve_dot_notation(
-                plugin_config.datastore_config_provider,
-                default_attr="Config",
-                default_prefix="nonebot_plugin_datastore.providers.",
-            )
-            self._config = ProviderClass(self)
+            self._config = _ProviderClass(self)
         return self._config
 
     def dump_pkl(self, data: Any, filename: str, cache: bool = False, **kwargs) -> None:
@@ -184,7 +179,7 @@ class PluginData(metaclass=Singleton):
             data = json.load(f, **kwargs)
         return data
 
-    def open(self, filename: str, mode: str = "r", cache: bool = False, **kwargs) -> IO:
+    def open(self, filename: str, mode: str = "r", cache: bool = False, **kwargs):
         """打开文件，默认打开数据文件夹下的文件"""
         if cache:
             path = self.cache_dir / filename
@@ -279,3 +274,11 @@ def get_plugin_data(name: Optional[str] = None) -> PluginData:
     name = name or get_caller_plugin_name()
 
     return PluginData(name)
+
+
+# 需要等到 PluginData 和 get_plugin_data 定义后才能导入对应的配置
+_ProviderClass = _resolve_dot_notation(
+    plugin_config.datastore_config_provider,
+    default_attr="Config",
+    default_prefix="nonebot_plugin_datastore.providers.",
+)

--- a/nonebot_plugin_datastore/providers/database.py
+++ b/nonebot_plugin_datastore/providers/database.py
@@ -4,7 +4,8 @@ from sqlalchemy import JSON, select
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.orm import Mapped, mapped_column
 
-from .. import create_session, get_plugin_data
+from ..db import create_session
+from ..plugin import get_plugin_data
 from . import ConfigProvider, KeyNotFoundError
 
 plugin_data = get_plugin_data()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -72,7 +72,6 @@ async def test_read_write_config(app: App):
     from nonebot_plugin_datastore.db import init_db
 
     data = PluginData("test")
-    assert data.config
 
     await init_db()
 
@@ -87,3 +86,7 @@ async def test_read_write_config(app: App):
     complex = {"a": 1, "b": [1, 2, 3], "c": {"d": 1}}
     await data.config.set("test", complex)
     assert await data.config.get("test") == complex
+
+    # 两个插件的配置不会相互影响
+    data1 = PluginData("test1")
+    assert await data1.config.get("test") is None


### PR DESCRIPTION
这下，如果设置为 ~database，数据库能正常初始化了。如果是其他设置，则不会初始化数据库。