### PR TITLE
fix: 修复在 Windows 上找不到迁移文件的问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 
 ## [Unreleased]
 
+### Fixed
+
+- 修复在 Windows 上找不到迁移文件的问题
+
 ## [0.6.0] - 2023-03-20
 
 ### Added

--- a/nonebot_plugin_datastore/script/utils.py
+++ b/nonebot_plugin_datastore/script/utils.py
@@ -58,6 +58,7 @@ class Config(AlembicConfig):
         self.set_main_option(
             "version_locations", str(PluginData(plugin_name).migration_dir)
         )
+        self.set_main_option("version_path_separator", "os")
 
 
 def do_run_migrations(connection, plugin_name: Optional[str] = None):


### PR DESCRIPTION
在未设置 `version_path_separator ` 的情况下，alembic 默认是用 `re.compile(r", *|(?: +)").split` 来处理 version_locations。如果 Python 的库在 `C:/Program Files` 下，会导致路径出错。

默认的 [配置](https://alembic.sqlalchemy.org/en/latest/tutorial.html#editing-the-ini-file) 为 `version_path_separator = os`。添加上这个配置后，一切正常。